### PR TITLE
 no type declaration because of possible custom model definition in c…

### DIFF
--- a/src/Traits/HasComments.php
+++ b/src/Traits/HasComments.php
@@ -42,7 +42,7 @@ trait HasComments
      *
      * @return static
      */
-    public function comment($data, Model $creator, Model $parent = null): Comment
+    public function comment($data, Model $creator, Model $parent = null)
     {
         $commentableModel = $this->commentableModel();
 


### PR DESCRIPTION
…onfig

This error is thrown:

```Type error: Return value of App\Company::comment() must be an instance of BrianFaust\Commentable\Models\Comment, instance of App\Comment returned```

Because of the Return type declaration "Comment" here in HasComments.php :

```
public function comment($data, Model $creator, Model $parent = null): Comment
    {
        $commentableModel = $this->commentableModel();

        $comment = (new $commentableModel())->createComment($this, $data, $creator);

        if (! empty($parent)) {
            $parent->appendNode($comment);
        }

        return $comment;
    }
```