### PR TITLE
Improve support for custom user providers

### DIFF
--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -60,7 +60,7 @@ class Comment extends Model
     public function createComment(Model $commentable, $data, Model $creator): self
     {
         return $commentable->comments()->create(array_merge($data, [
-            'creator_id'   => $creator->id,
+            'creator_id'   => $creator->getAuthIdentifier(),
             'creator_type' => get_class($creator),
         ]));
     }


### PR DESCRIPTION
Custom user providers might implement databases which do not use id as a default identifier. The getAuthIdentifier() allows the user provider to specify which key is the actual auth identifier.