### PR TITLE
Upgrading to Laravel 5.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ktotheoz/laravel-commentable",
+    "name": "faustbrian/laravel-commentable",
     "description": "Commentable Polymorphic Eloquent Models for for Laravel 5",
     "keywords": ["laravel", "framework", "Laravel-Commentable", "Laravel Commentable", "Brian Faust", "faustbrian"],
     "license": "MIT",
@@ -7,10 +7,6 @@
         "name": "Brian Faust",
         "email": "hello@brianfaust.me",
         "homepage": "https://brianfaust.me"
-    },{
-        "name": "Markus Naether",
-        "email": "naether.markus@gmail.com",
-        "homepage": ""
     }],
     "require": {
         "php": "^7.1",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "faustbrian/laravel-commentable",
+    "name": "ktotheoz/laravel-commentable",
     "description": "Commentable Polymorphic Eloquent Models for for Laravel 5",
     "keywords": ["laravel", "framework", "Laravel-Commentable", "Laravel Commentable", "Brian Faust", "faustbrian"],
     "license": "MIT",
@@ -7,6 +7,10 @@
         "name": "Brian Faust",
         "email": "hello@brianfaust.me",
         "homepage": "https://brianfaust.me"
+    },{
+        "name": "Markus Naether",
+        "email": "naether.markus@gmail.com",
+        "homepage": ""
     }],
     "require": {
         "php": "^7.1",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     }],
     "require": {
         "php": "^7.1",
-        "illuminate/support": "5.5.* || 5.6.*",
-        "illuminate/database": "5.5.* || 5.6.*",
+        "illuminate/support": "5.5.* || 5.6.* || 5.7.*",
+        "illuminate/database": "5.5.* || 5.6.* || 5.7.*",
         "kalnoy/nestedset": "^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
There are no major changes to Laravel 5.7.*, so one can simply add 5.7.* to the list of required versions.